### PR TITLE
nodejs 10 -> nodejs14

### DIFF
--- a/lambda_basic_auth.tf
+++ b/lambda_basic_auth.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "auth" {
   function_name    = "basic_auth_${var.environment}"
   role             = aws_iam_role.lambda_at_edge_role.arn
   handler          = "lambda.handler"
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs14.x"
   source_code_hash = data.archive_file.auth_zip.output_base64sha256
   publish          = "true"
 }

--- a/lambda_hsts.tf
+++ b/lambda_hsts.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "hsts_protection" {
   function_name    = var.environment == "" ? "hsts_protection" : "hsts_protection_${var.environment}"
   role             = aws_iam_role.lambda_at_edge_role.arn
   handler          = "hsts.handler"
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs14.x"
   source_code_hash = data.archive_file.hsts_zip.output_base64sha256
   publish          = "true"
 }

--- a/lambda_iam.tf
+++ b/lambda_iam.tf
@@ -41,6 +41,7 @@ resource "aws_iam_policy" "lambda_at_edge_policy" {
 EOF
 }
 resource "aws_iam_role_policy_attachment" "log-attach" {
+  count      = var.enable_logging ? 1 : 0
   role       = aws_iam_role.lambda_at_edge_role.name
   policy_arn = aws_iam_policy.lambda_at_edge_policy.arn
 }

--- a/lambda_seo_prerender.tf
+++ b/lambda_seo_prerender.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "prerender" {
   function_name    = var.environment == "" ? "prerender" : "prerender_${var.environment}"
   role             = aws_iam_role.lambda_at_edge_role.arn
   handler          = "lambda.handler"
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs14.x"
   source_code_hash = data.archive_file.prerender_zip.output_base64sha256
   publish          = "true"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,7 @@ variable "allowed_headers" {
   description = "Allowed Methods"
   default     = ["*"]
 }
+variable "enable_logging" {
+  description = "Enable logging IAM permissions"
+  default     = true
+}


### PR DESCRIPTION
A. We are ending support for Node.js 10 in AWS Lambda on July 30, 2021. This follows the Node.js language governing body declaring Node.js 10 end of life as of April 30, 2021 [1].